### PR TITLE
Helm chart for multiple validators.

### DIFF
--- a/eth2prysm/templates/beacon-deployment.yaml
+++ b/eth2prysm/templates/beacon-deployment.yaml
@@ -20,13 +20,11 @@ spec:
     spec:
       containers:
       - name: {{ .name }}
-        {{- with $.Values.image }}
-        image: "{{ .beaconImage }}:{{ .version }}"
-        {{- end }}
+        image: "{{ $.Values.image.beaconImage }}:{{ $.Values.image.version }}"
         args:
         {{- if $.Values.ethereumTestnet }}
         - --{{ $.Values.ethereumTestnet }}
-        {{- end}}
+        {{- end }}
         - --rpc-host=0.0.0.0
         - --p2p-tcp-port={{ .p2pTcpPort }}
         - --p2p-udp-port={{ .p2pUdpPort }}
@@ -51,20 +49,20 @@ spec:
           mountPath: /data/prysm/beacon
       volumes:
       - name: beacon-storage
-        {{- if $.Values.nfsEnabled }}
+        {{- if eq $.Values.persistentVolumeType "nfs" }}
         nfs:
           path: {{ .dataVolumePath }}
-          server: {{ $.Values.nfsServerIp }}
+          server: {{ $.Values.nfs.serverIp }}
           readOnly: false
-        {{- else}}
+        {{- else }}
         hostPath:
           path: {{ .dataVolumePath }}
-        {{- end}}
-      {{- if $.Values.nfsEnabled }}
+        {{- end }}
+      {{- if eq $.Values.persistentVolumeType "nfs" }}
       securityContext:
-        runAsUser: {{ $.Values.nfsUser }}
-        runAsGroup: {{ $.Values.nfsGroup }} 
-      {{- end}}
+        runAsUser: {{ $.Values.nfs.user }}
+        runAsGroup: {{ $.Values.nfs.group }} 
+      {{- end }}
       serviceAccountName: beacon
       restartPolicy: Always
 {{- end }}

--- a/eth2prysm/templates/beacon-deployment.yaml
+++ b/eth2prysm/templates/beacon-deployment.yaml
@@ -1,41 +1,47 @@
+{{- with .Values.beacon }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Values.beacon.name }}
-  namespace: {{ .Values.namespace }}
+  name: {{ .name }}
+  namespace: {{ $.Values.namespace }}
   labels:
-    app: {{ .Values.beacon.name }}
+    app: {{ .name }}
 spec:
   selector:
     matchLabels:
-      app: {{ .Values.beacon.name }}
+      app: {{ .name }}
   replicas: 1
   strategy: 
     type: Recreate
   template:
     metadata:
       labels:
-        app: {{ .Values.beacon.name }}
+        app: {{ .name }}
     spec:
       containers:
-      - name: {{ .Values.beacon.name }}
-        image: gcr.io/prysmaticlabs/prysm/beacon-chain:{{ .Values.imageVersion }}
+      - name: {{ .name }}
+        {{- with $.Values.image }}
+        image: "{{ .beaconImage }}:{{ .version }}"
+        {{- end }}
         args:
-        {{- if .Values.ethereumTestnet }}
-        - --{{ .Values.ethereumTestnet }}
+        {{- if $.Values.ethereumTestnet }}
+        - --{{ $.Values.ethereumTestnet }}
         {{- end}}
         - --rpc-host=0.0.0.0
-        - --p2p-tcp-port={{ .Values.beacon.p2pTcpPort }}
-        - --p2p-udp-port={{ .Values.beacon.p2pUdpPort }}
-        - --http-web3provider={{ .Values.beacon.web3provider }}
+        - --p2p-tcp-port={{ .p2pTcpPort }}
+        - --p2p-udp-port={{ .p2pUdpPort }}
+        - --http-web3provider={{ .web3Provider }}
+        {{- range .fallbackWeb3Providers }}
+        - --fallback-web3provider={{ . }}
+        {{- end }}
         - --datadir=/data/prysm/beacon
         - --accept-terms-of-use
         ports:
-        - containerPort: {{ .Values.beacon.p2pTcpPort }}
-          hostPort: {{ .Values.beacon.p2pTcpPort }}
+        - containerPort: {{ .p2pTcpPort }}
+          hostPort: {{ .p2pTcpPort }}
           protocol: TCP
-        - containerPort: {{ .Values.beacon.p2pUdpPort }}
-          hostPort: {{ .Values.beacon.p2pUdpPort }}
+        - containerPort: {{ .p2pUdpPort }}
+          hostPort: {{ .p2pUdpPort }}
           protocol: UDP
         - containerPort: 4000
           protocol: TCP
@@ -45,7 +51,20 @@ spec:
           mountPath: /data/prysm/beacon
       volumes:
       - name: beacon-storage
+        {{- if $.Values.nfsEnabled }}
+        nfs:
+          path: {{ .dataVolumePath }}
+          server: {{ $.Values.nfsServerIp }}
+          readOnly: false
+        {{- else}}
         hostPath:
-          path: {{ .Values.beacon.dataHostPath }}
+          path: {{ .dataVolumePath }}
+        {{- end}}
+      {{- if $.Values.nfsEnabled }}
+      securityContext:
+        runAsUser: {{ $.Values.nfsUser }}
+        runAsGroup: {{ $.Values.nfsGroup }} 
+      {{- end}}
       serviceAccountName: beacon
       restartPolicy: Always
+{{- end }}

--- a/eth2prysm/templates/validator-deployment.yaml
+++ b/eth2prysm/templates/validator-deployment.yaml
@@ -1,38 +1,43 @@
+{{- range $key, $validator := .Values.validators }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Values.validator.name }}
-  namespace: {{ .Values.namespace }}
+  name: {{ $validator.name }}
+  namespace: {{ $.Values.namespace }}
   labels:
-    app: {{ .Values.validator.name }}
+    app: {{ $validator.name }}
 spec:
   selector:
     matchLabels:
-      app: {{ .Values.validator.name }}
+      app: {{ $validator.name }}
   replicas: 1
   strategy: 
     type: Recreate
   template:
     metadata:
       labels:
-        app: {{ .Values.validator.name }}
+        app: {{ $validator.name }}
+      annotations:
+        checksum/config: {{ $validator.walletPassword | sha256sum }}
     spec:
       initContainers:
       - name: init-wait
         image: alpine:3.13.2
-        command: ['sh', '-c', 'echo "Wait for {{ .Values.validator.startWaitTime }} second(s) for extra slashing protection!" && sleep {{ .Values.validator.startWaitTime }}']
+        command: ['sh', '-c', 'echo "Wait for {{ $validator.startWaitTime }} second(s) for extra slashing protection!" && sleep {{ $validator.startWaitTime }}']
       containers:
-      - name: {{ .Values.validator.name }}
-        image: gcr.io/prysmaticlabs/prysm/validator:{{ .Values.imageVersion }}
+      - name: {{ $validator.name }}
+        {{- with $.Values.image }}
+        image: "{{ .validatorImage }}:{{ .version }}"
+        {{- end }}
         args:
-        {{- if .Values.ethereumTestnet }}
-        - --{{ .Values.ethereumTestnet }}
+        {{- if $.Values.ethereumTestnet }}
+        - --{{ $.Values.ethereumTestnet }}
         {{- end}} 
-        - --beacon-rpc-provider={{ .Values.beacon.name }}-service.{{ .Values.namespace }}.svc.cluster.local:4000
+        - --beacon-rpc-provider={{ $.Values.beacon.name }}-service.{{ $.Values.namespace }}.svc.cluster.local:4000
         - --datadir=/data/prysm/validator 
         - --wallet-dir=/data/prysm/wallet 
         - --wallet-password-file=/data/prysm/password/wallet_pass.txt
-        - --graffiti={{ .Values.validator.graffiti | quote }} 
+        - --graffiti={{ $validator.graffiti | quote }} 
         - --accept-terms-of-use
         volumeMounts:
         - name: validator-storage
@@ -46,16 +51,38 @@ spec:
           readOnly: true
       volumes:
       - name: validator-storage
+        {{- if $.Values.nfsEnabled }}
+        nfs:
+          path: {{ $validator.dataVolumePath }}
+          server: {{ $.Values.nfsServerIp }}
+          readOnly: false
+        {{- else }}
         hostPath:
-          path: {{ .Values.validator.dataHostPath }}
-      - name: wallet-storage 
+          path: {{ $validator.dataVolumePath }}
+        {{- end }}
+      - name: wallet-storage
+        {{- if $.Values.nfsEnabled }}
+        nfs:
+          path: {{ $validator.walletVolumePath }}
+          server: {{ $.Values.nfsServerIp }}
+          readOnly: false
+        {{- else }}
         hostPath:
-          path: {{ .Values.validator.walletHostPath }}
+          path: {{ $validator.walletVolumePath }}
+        {{- end }}
       - name: wallet-password
         secret:
-          secretName: wallet-password
+          secretName: {{ $validator.walletPasswordSecretName }}
           items:
           - key: password
             path: wallet_pass.txt
+      {{- if $.Values.nfsEnabled }}
+      securityContext:
+        runAsUser: {{ $.Values.nfsUser }}
+        runAsGroup: {{ $.Values.nfsGroup }}
+      {{- end }}
       serviceAccountName: validator
       restartPolicy: Always
+
+---
+{{- end}}

--- a/eth2prysm/templates/validator-deployment.yaml
+++ b/eth2prysm/templates/validator-deployment.yaml
@@ -23,16 +23,14 @@ spec:
       initContainers:
       - name: init-wait
         image: alpine:3.13.2
-        command: ['sh', '-c', 'echo "Wait for {{ $validator.startWaitTime }} second(s) for extra slashing protection!" && sleep {{ $validator.startWaitTime }}']
+        command: ['sh', '-c', 'echo "Wait for {{ $.Values.validatorStartWaitTime }} second(s) for extra slashing protection!" && sleep {{ $.Values.validatorStartWaitTime }}']
       containers:
       - name: {{ $validator.name }}
-        {{- with $.Values.image }}
-        image: "{{ .validatorImage }}:{{ .version }}"
-        {{- end }}
+        image: "{{ $.Values.image.validatorImage }}:{{ $.Values.image.version }}"
         args:
         {{- if $.Values.ethereumTestnet }}
         - --{{ $.Values.ethereumTestnet }}
-        {{- end}} 
+        {{- end }}
         - --beacon-rpc-provider={{ $.Values.beacon.name }}-service.{{ $.Values.namespace }}.svc.cluster.local:4000
         - --datadir=/data/prysm/validator 
         - --wallet-dir=/data/prysm/wallet 
@@ -51,20 +49,20 @@ spec:
           readOnly: true
       volumes:
       - name: validator-storage
-        {{- if $.Values.nfsEnabled }}
+        {{- if eq $.Values.persistentVolumeType "nfs" }}
         nfs:
           path: {{ $validator.dataVolumePath }}
-          server: {{ $.Values.nfsServerIp }}
+          server: {{ $.Values.nfs.serverIp }}
           readOnly: false
         {{- else }}
         hostPath:
           path: {{ $validator.dataVolumePath }}
         {{- end }}
       - name: wallet-storage
-        {{- if $.Values.nfsEnabled }}
+        {{- if eq $.Values.persistentVolumeType "nfs" }}
         nfs:
           path: {{ $validator.walletVolumePath }}
-          server: {{ $.Values.nfsServerIp }}
+          server: {{ $.Values.nfs.serverIp }}
           readOnly: false
         {{- else }}
         hostPath:
@@ -76,13 +74,13 @@ spec:
           items:
           - key: password
             path: wallet_pass.txt
-      {{- if $.Values.nfsEnabled }}
+      {{- if eq $.Values.persistentVolumeType "nfs" }}
       securityContext:
-        runAsUser: {{ $.Values.nfsUser }}
-        runAsGroup: {{ $.Values.nfsGroup }}
+        runAsUser: {{ $.Values.nfs.user }}
+        runAsGroup: {{ $.Values.nfs.group }}
       {{- end }}
       serviceAccountName: validator
       restartPolicy: Always
 
 ---
-{{- end}}
+{{- end }}

--- a/eth2prysm/templates/wallet-secret.yaml
+++ b/eth2prysm/templates/wallet-secret.yaml
@@ -9,4 +9,4 @@ stringData:
   password: {{ $validator.walletPassword }}
 
 ---
-{{- end}}
+{{- end }}

--- a/eth2prysm/templates/wallet-secret.yaml
+++ b/eth2prysm/templates/wallet-secret.yaml
@@ -1,8 +1,12 @@
+{{- range $key, $validator := .Values.validators }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: wallet-password
-  namespace: {{ .Values.namespace }}
+  name: {{ $validator.walletPasswordSecretName }}
+  namespace: {{ $.Values.namespace }}
 type: Opaque
 stringData:
-  password: {{ .Values.validator.walletPassword }}
+  password: {{ $validator.walletPassword }}
+
+---
+{{- end}}

--- a/eth2prysm/values.yaml
+++ b/eth2prysm/values.yaml
@@ -5,10 +5,14 @@ namespace: prysm
 
 ethereumTestnet: pyrmont
 
-nfsEnabled: true
-nfsServerIp: 172.20.10.10
-nfsUser: 1001
-nfsGroup: 2000
+# A required field that determines the persistent storage type. Default to hostPath.
+# Available options: nfs and hostPath.
+persistentVolumeType: "nfs"
+
+nfs:
+  serverIp: 172.20.10.10
+  user: 1001
+  group: 2000
 
 image:
   beaconImage: gcr.io/prysmaticlabs/prysm/beacon-chain
@@ -25,14 +29,17 @@ beacon:
     - http://127.0.0.1:8546
     - http://127.0.0.1:8547
 
+# This field determines how long it will wait before the validator starts or restarts.
+# It's a way to protect the validator from double attesting or block proposing when the DB is out-of-date.
+validatorStartWaitTime: 780
+
 validators:
   validator1:
     name: validator1
     dataVolumePath: /data/prysm/validator-1
     walletVolumePath: /data/prysm/wallet-1
     walletPasswordSecretName: wallet-password-1
-    walletPassword: "example-password-1"
-    startWaitTime: 780
+    walletPassword: "example-password-1"  
     graffiti: "eth2 x k8s"
     
   validator2:
@@ -41,6 +48,5 @@ validators:
     walletVolumePath: /data/prysm/wallet-2
     walletPasswordSecretName: wallet-password-2
     walletPassword: "example-password-2"
-    startWaitTime: 780
     graffiti: "eth2 x k8s"
     

--- a/eth2prysm/values.yaml
+++ b/eth2prysm/values.yaml
@@ -49,4 +49,3 @@ validators:
     walletPasswordSecretName: wallet-password-2
     walletPassword: "example-password-2"
     graffiti: "eth2 x k8s"
-    

--- a/eth2prysm/values.yaml
+++ b/eth2prysm/values.yaml
@@ -2,21 +2,45 @@
 # This is a YAML-formatted file.
 
 namespace: prysm
-imageVersion: v1.3.3
 
 ethereumTestnet: pyrmont
 
+nfsEnabled: true
+nfsServerIp: 172.20.10.10
+nfsUser: 1001
+nfsGroup: 2000
+
+image:
+  beaconImage: gcr.io/prysmaticlabs/prysm/beacon-chain
+  validatorImage: gcr.io/prysmaticlabs/prysm/validator 
+  version: v1.3.3
+
 beacon:
   name: beacon
-  dataHostPath: /data/prysm/beacon
-  web3provider: http://127.0.0.1:8545
+  dataVolumePath: /data/prysm/beacon
   p2pUdpPort: 12000
   p2pTcpPort: 13000
+  web3Provider: http://127.0.0.1:8545
+  fallbackWeb3Providers:
+    - http://127.0.0.1:8546
+    - http://127.0.0.1:8547
 
-validator:
-  name: validator
-  startWaitTime: 780
-  dataHostPath: /data/prysm/validator
-  graffiti: "eth2 x k8s"
-  walletHostPath: /data/prysm/wallet
-  walletPassword: "example-password"
+validators:
+  validator1:
+    name: validator1
+    dataVolumePath: /data/prysm/validator-1
+    walletVolumePath: /data/prysm/wallet-1
+    walletPasswordSecretName: wallet-password-1
+    walletPassword: "example-password-1"
+    startWaitTime: 780
+    graffiti: "eth2 x k8s"
+    
+  validator2:
+    name: validator2
+    dataVolumePath: /data/prysm/validator-2
+    walletVolumePath: /data/prysm/wallet-2
+    walletPasswordSecretName: wallet-password-2
+    walletPassword: "example-password-2"
+    startWaitTime: 780
+    graffiti: "eth2 x k8s"
+    


### PR DESCRIPTION
- Add NFS persistent storage support (tested with k3s).
- Add multiple validators support.
- Add [fallback web3provider ](https://docs.prylabs.network/docs/prysm-usage/setup-eth1/#adding-fallback-eth1-nodes) for prysm beacon node.
- Roll deployment when wallet password changes. 
- Add image base URL variable.