### PR TITLE
Lighthouse helm chart

### DIFF
--- a/lighthouse/helm/.helmignore
+++ b/lighthouse/helm/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/lighthouse/helm/Chart.yaml
+++ b/lighthouse/helm/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v2
+name: eth2-lighthouse
+description: A Helm chart for Ethereum 2 client - Lighthouse
+
+type: application
+version: 0.1.0
+appVersion: "1.3.0"

--- a/lighthouse/helm/templates/beacon-deployment.yaml
+++ b/lighthouse/helm/templates/beacon-deployment.yaml
@@ -1,0 +1,64 @@
+{{- with .Values.beacon }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .name }}
+  namespace: {{ $.Values.namespace }}
+  labels:
+    app: {{ .name }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ .name }}
+  replicas: 1
+  strategy: 
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: {{ .name }}
+    spec:
+      containers:
+      - name: {{ .name }}
+        image: "{{ $.Values.image.beaconImage }}:{{ $.Values.image.version }}"
+        args:
+        - lighthouse
+        {{- if $.Values.ethereumTestnet }}
+        - --network={{ $.Values.ethereumTestnet }}
+        {{- end }}
+        - bn
+        - --staking
+        - --http-address=0.0.0.0
+        - --eth1-endpoints={{ .eth1Endpoints | join "," }}
+        - --datadir=/data/lighthouse/beacon
+        ports:
+        - containerPort: 9000
+          hostPort: 9000
+          protocol: TCP
+        - containerPort: 9000
+          hostPort: 9000
+          protocol: UDP
+        - containerPort: 5052
+          protocol: TCP
+        volumeMounts:
+        - name: beacon-storage
+          mountPath: /data/lighthouse/beacon
+      volumes:
+      - name: beacon-storage
+        {{- if eq $.Values.persistentVolumeType "nfs" }}
+        nfs:
+          path: {{ .dataVolumePath }}
+          server: {{ $.Values.nfs.serverIp }}
+          readOnly: false
+        {{- else }}
+        hostPath:
+          path: {{ .dataVolumePath }}
+        {{- end }}
+      {{- if eq $.Values.persistentVolumeType "nfs" }}
+      securityContext:
+        runAsUser: {{ $.Values.nfs.user }}
+        runAsGroup: {{ $.Values.nfs.group }} 
+      {{- end }} 
+      serviceAccountName: beacon
+      restartPolicy: Always
+{{- end }}

--- a/lighthouse/helm/templates/beacon-deployment.yaml
+++ b/lighthouse/helm/templates/beacon-deployment.yaml
@@ -54,11 +54,9 @@ spec:
         hostPath:
           path: {{ .dataVolumePath }}
         {{- end }}
-      {{- if eq $.Values.persistentVolumeType "nfs" }}
       securityContext:
         runAsUser: {{ $.Values.nfs.user }}
         runAsGroup: {{ $.Values.nfs.group }} 
-      {{- end }} 
       serviceAccountName: beacon
       restartPolicy: Always
 {{- end }}

--- a/lighthouse/helm/templates/beacon-service.yaml
+++ b/lighthouse/helm/templates/beacon-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.beacon.name }}-service
+  namespace: {{ .Values.namespace }}
+spec:
+  selector:
+    app: {{ .Values.beacon.name }}
+  ports:
+    - protocol: TCP
+      port: 5052
+      targetPort: 5052

--- a/lighthouse/helm/templates/rbac.yaml
+++ b/lighthouse/helm/templates/rbac.yaml
@@ -1,0 +1,40 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: beacon
+  namespace: {{ .Values.namespace }}
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: validator-client
+  namespace: {{ .Values.namespace }}
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: lighthouse
+rules:
+- apiGroups: ['policy']
+  resources: ['podsecuritypolicies']
+  verbs:     ['use']
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: lighthouse-cluster-role-rolebinding
+roleRef:
+  kind: ClusterRole
+  name: lighthouse
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+# Authorize specific service accounts:
+- kind: ServiceAccount
+  name: beacon
+  namespace: {{ .Values.namespace }}
+- kind: ServiceAccount
+  name: validator-client
+  namespace: {{ .Values.namespace }}

--- a/lighthouse/helm/templates/validator-deployment.yaml
+++ b/lighthouse/helm/templates/validator-deployment.yaml
@@ -32,11 +32,11 @@ spec:
         {{- end }}
         - vc
         - --beacon-nodes=http://{{ $.Values.beacon.name }}-service.{{ $.Values.namespace }}.svc.cluster.local:5052
-        - --datadir=/data/lighthouse/validator-client
+        - --datadir={{ $validatorClient.dataVolumePath }}
         - --graffiti={{ $validatorClient.graffiti | quote }}
         volumeMounts:
         - name: validator-client-storage
-          mountPath: /data/lighthouse/validator-client
+          mountPath: {{ $validatorClient.dataVolumePath }}
           readOnly: false
       volumes:
       - name: validator-client-storage

--- a/lighthouse/helm/templates/validator-deployment.yaml
+++ b/lighthouse/helm/templates/validator-deployment.yaml
@@ -1,0 +1,59 @@
+{{- range $key, $validatorClient := .Values.validatorClients }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $validatorClient.name }}
+  namespace: {{ $.Values.namespace }}
+  labels:
+    app: {{ $validatorClient.name }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ $validatorClient.name }}
+  replicas: 1
+  strategy: 
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: {{ $validatorClient.name }}
+    spec:
+      initContainers:
+      - name: init-wait
+        image: alpine:3.13.2
+        command: ['sh', '-c', 'echo "Wait for {{ $.Values.validatorStartWaitTime }} second(s) for extra slashing protection!" && sleep {{ $.Values.validatorStartWaitTime }}']
+      containers:
+      - name: {{ $validatorClient.name }}
+        image: "{{ $.Values.image.validatorImage }}:{{ $.Values.image.version }}"
+        args:
+        - lighthouse
+        - --network=prater
+        - vc
+        - --beacon-nodes=http://{{ $.Values.beacon.name }}-service.{{ $.Values.namespace }}.svc.cluster.local:5052
+        - --datadir=/data/lighthouse/validator-client
+        - --graffiti={{ $validatorClient.graffiti | quote }}
+        volumeMounts:
+        - name: validator-client-storage
+          mountPath: /data/lighthouse/validator-client
+          readOnly: false
+      volumes:
+      - name: validator-client-storage
+        {{- if eq $.Values.persistentVolumeType "nfs" }}
+        nfs:
+          path: {{ $validatorClient.dataVolumePath }}
+          server: {{ $.Values.nfs.serverIp }}
+          readOnly: false
+        {{- else }}
+        hostPath:
+          path: {{ $validatorClient.dataVolumePath }}
+        {{- end }}
+      {{- if eq $.Values.persistentVolumeType "nfs" }}
+      securityContext:
+        runAsUser: {{ $.Values.nfs.user }}
+        runAsGroup: {{ $.Values.nfs.group }}
+      {{- end }}
+      serviceAccountName: validator-client
+      restartPolicy: Always
+
+---
+{{- end }}

--- a/lighthouse/helm/templates/validator-deployment.yaml
+++ b/lighthouse/helm/templates/validator-deployment.yaml
@@ -27,7 +27,9 @@ spec:
         image: "{{ $.Values.image.validatorImage }}:{{ $.Values.image.version }}"
         args:
         - lighthouse
-        - --network=prater
+        {{- if $.Values.ethereumTestnet }}
+        - --network={{ $.Values.ethereumTestnet }}
+        {{- end }}
         - vc
         - --beacon-nodes=http://{{ $.Values.beacon.name }}-service.{{ $.Values.namespace }}.svc.cluster.local:5052
         - --datadir=/data/lighthouse/validator-client
@@ -47,11 +49,9 @@ spec:
         hostPath:
           path: {{ $validatorClient.dataVolumePath }}
         {{- end }}
-      {{- if eq $.Values.persistentVolumeType "nfs" }}
       securityContext:
         runAsUser: {{ $.Values.nfs.user }}
         runAsGroup: {{ $.Values.nfs.group }}
-      {{- end }}
       serviceAccountName: validator-client
       restartPolicy: Always
 

--- a/lighthouse/helm/values.yaml
+++ b/lighthouse/helm/values.yaml
@@ -1,7 +1,7 @@
 # Default values for eth2-lighthouse.
 # This is a YAML-formatted file.
 
-# Kubernetes namespace for lighthouse beacon chain and validator deployments, services, secrets, etc.
+# Kubernetes namespace for lighthouse beacon chain and validator client deployments, services, secrets, etc.
 namespace: lighthouse
 
 # Specify which Ethereum 2.0 testnet to use. If the target network is mainnet, leave this field blank.
@@ -25,7 +25,7 @@ nfs:
   # All directories and files created with the processes are owned by this group.
   group: 2000
 
-# A required section that configures beacon chain and validator images registry and version.
+# A required section that configures image registry, image name and version tag for beacon chain and validator client.
 # Lighthouse currently pushes images to:
 #   Docker Hub: https://hub.docker.com/r/sigp/lighthouse
 image:
@@ -52,8 +52,8 @@ beacon:
     - http://127.0.0.1:8545
     - http://127.0.0.1:8546
     
-# This field determines how long it will wait before the validator starts or restarts.
-# It's a way to protect the validator from double attesting or block proposing when the DB is out-of-date.
+# This field determines how long it will wait before the validator client starts or restarts.
+# It's a way to protect the validator client from double attesting or block proposing when the DB is out-of-date.
 validatorStartWaitTime: 780
 
 # A required section that contains information for all validator clients
@@ -61,14 +61,14 @@ validatorClients:
   # This section contains information for one validator client.
   # "validatorClient1" is the name of this validator client section. You can change it to other strings as long as it's different than other section names.
   validatorClient1:
-    # This field specifies the name and label for validator deployment, container and service.
+    # This field specifies the name and label for validator client deployment, container and service.
     name: validator-client-1
     # The volume path of validator client data. 
     # If persistentVolumeType is set to "nfs", this variable represents the data volume path on NFS.
     # If the type is set to "hostPath", it represents the volume path on the host node.
     # It's recommended to have different value for each validator client to avoid using the wrong validator client data.
     dataVolumePath: /data/lighthouse/validator-client-1  
-    # A mark you want to leave each time the validator proposes a block.
+    # A mark you want to leave each time the validator client proposes a block.
     # It can be a message or a pixel (on the graffiti wall).
     # See https://beaconcha.in/charts/graffiti_wordcloud for example.
     graffiti: "eth2 x k8s"

--- a/lighthouse/helm/values.yaml
+++ b/lighthouse/helm/values.yaml
@@ -1,0 +1,86 @@
+# Default values for eth2-lighthouse.
+# This is a YAML-formatted file.
+
+# Kubernetes namespace for lighthouse beacon chain and validator deployments, services, secrets, etc.
+namespace: lighthouse
+
+# Specify which Ethereum 2.0 testnet to use. If the target network is mainnet, leave this field blank.
+ethereumTestnet: prater
+
+# A required field that determines the persistent storage type. Default to hostPath.
+# Available options: nfs and hostPath.
+persistentVolumeType: "nfs"
+
+# NFS configurations. Only need to fill this section when persistentVolumeType is set to "nfs".
+nfs:
+  # IP address of the NFS server.
+  serverIp: 172.20.10.10
+  # The user ID will be used to run all processes in the container. The user should have the access to the mounted NFS volume.
+  # All directories and files created with the processes are owned by this user.
+  user: 1001
+  # The group ID will be used to run all processes in the container. The group should have the access to the mounted NFS volume.
+  # If this field is not set, the group ID of the processes will be 0, which means they will have root access.
+  # See https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ for more info.
+  #
+  # All directories and files created with the processes are owned by this group.
+  group: 2000
+
+# A required section that configures beacon chain and validator images registry and version.
+# Lighthouse currently pushes images to:
+#   Docker Hub: https://hub.docker.com/r/sigp/lighthouse
+image:
+  # The image registry of beacon chain:
+  #   Docker Hub: index.docker.io/sigp/lighthouse
+  beaconImage: index.docker.io/sigp/lighthouse
+  # The image registry of validator:
+  #   Docker Hub: index.docker.io/sigp/lighthouse
+  validatorImage: index.docker.io/sigp/lighthouse
+  # Lighthouse release version. 
+  # Check https://github.com/sigp/lighthouse/releases for more info. 
+  version: v1.3.0
+
+# A required section that contains beacon chain information.
+beacon:
+  # This field specifies the name and label for beacon chain deployment, container and service.
+  name: beacon
+  # The volume path of beacon chain data. 
+  # If persistentVolumeType is set to "nfs", this variable represents the data volume path on NFS.
+  # If the type is set to "hostPath", it represents the volume path on the host node.
+  dataVolumePath: /data/lighthouse/beacon
+  # Ethereum 1 node endpoints.
+  eth1Endpoints: 
+    - http://127.0.0.1:8545
+    - http://127.0.0.1:8546
+    
+# This field determines how long it will wait before the validator starts or restarts.
+# It's a way to protect the validator from double attesting or block proposing when the DB is out-of-date.
+validatorStartWaitTime: 780
+
+# A required section that contains information for all validator clients
+validatorClients:
+  # This section contains information for one validator client.
+  # "validatorClient1" is the name of this validator client section. You can change it to other strings as long as it's different than other section names.
+  validatorClient1:
+    # This field specifies the name and label for validator deployment, container and service.
+    name: validator-client-1
+    # The volume path of validator client data. 
+    # If persistentVolumeType is set to "nfs", this variable represents the data volume path on NFS.
+    # If the type is set to "hostPath", it represents the volume path on the host node.
+    # It's recommended to have different value for each validator client to avoid using the wrong validator client data.
+    dataVolumePath: /data/lighthouse/validator-client-1  
+    # A mark you want to leave each time the validator proposes a block.
+    # It can be a message or a pixel (on the graffiti wall).
+    # See https://beaconcha.in/charts/graffiti_wordcloud for example.
+    graffiti: "eth2 x k8s"
+    
+  validatorClient2:
+    name: validator-client-2
+    dataVolumePath: /data/lighthouse/validator-client-2
+    graffiti: "eth2 x k8s"
+  
+  # You can add more validator clients below. The name of a new validator client section can be validatorClient3 or anything else that you prefer
+  # as long as the section has the same indentation as other validator client sections and contains all the fields under the section name.
+  # validatorClient3:
+  #   name: 
+  #   dataVolumePath: 
+  #   graffiti: 


### PR DESCRIPTION
- Change from validator to validator client
- Add securityContext to both NFS and hostPath
- Specify mounted volume for --datadir flag since the vc might look for voting_keystore_path in validator_definitions.yaml.