### PR TITLE
Rename to versionTag and eth1Endpoints. Bump Chart and client versions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ If the goal is to run Ethereum 2.0 clients on mainnet, we recommend:
 
     For Prysm:
     - **beacon.dataDirPath**: The path to the data directory on the NFS for the beacon node.
-    - **beacon.web3Provider** and **beacon.fallbackWeb3Providers**: Ethereum 1.0 node endpoints.
+    - **beacon.eth1Endpoints**: Ethereum 1.0 node endpoints.
     - **validatorClients.validatorClient1**
       - **.dataDirPath**: The path to the data directory on the NFS for the validator client.
       - **.walletDirPath**: The path to the data directory on the NFS for the wallet.
@@ -66,7 +66,7 @@ If the goal is to run Ethereum 2.0 clients on mainnet, we recommend:
 
     For Teku:
     - **beacon.dataDirPath**: The path to the data directory on the NFS for the beacon node.
-    - **beacon.eth1Endpoint**: Ethereum 1.0 node endpoint.
+    - **beacon.eth1Endpoints**: Ethereum 1.0 node endpoints.
     - **validatorClients.validatorClient1**
       - **.dataDirPath**: The path to the data directory on the NFS for the validator client.
       - **.validatorKeysDirPath**: The path to the data directory on the NFS for the validator keys.
@@ -74,7 +74,7 @@ If the goal is to run Ethereum 2.0 clients on mainnet, we recommend:
 
     For Nimbus:
     - **nimbus.clients.client1**
-      - **.web3Provider** and **.fallbackWeb3Providers**: Ethereum 1.0 node endpoints.
+      - **.eth1Endpoints**: Ethereum 1.0 node endpoints.
       - **.dataDirPath**: The path to the data directory on the NFS for the beacon node.
       - **.validatorsDirPath**: The path to the data directory on the NFS for the validator keystores.
       - **.secretsDirPath**: The path to the data directory on the NFS for the validator keystore passwords.

--- a/lighthouse/helm/Chart.yaml
+++ b/lighthouse/helm/Chart.yaml
@@ -3,5 +3,5 @@ name: eth2-lighthouse
 description: A Helm chart for Ethereum 2 client - Lighthouse
 
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: "1.3.0"

--- a/lighthouse/helm/templates/beacon-deployment.yaml
+++ b/lighthouse/helm/templates/beacon-deployment.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
       - name: {{ .name }}
-        image: "{{ $.Values.image.beaconImage }}:{{ $.Values.image.version }}"
+        image: "{{ $.Values.image.beaconImage }}:{{ $.Values.image.versionTag }}"
         args:
         - lighthouse
         {{- if $.Values.ethereumTestnet }}

--- a/lighthouse/helm/templates/validator-deployment.yaml
+++ b/lighthouse/helm/templates/validator-deployment.yaml
@@ -24,7 +24,7 @@ spec:
         command: ['sh', '-c', 'echo "Wait for {{ $.Values.validatorStartWaitTime }} second(s) for extra slashing protection!" && sleep {{ $.Values.validatorStartWaitTime }}']
       containers:
       - name: {{ $validatorClient.name }}
-        image: "{{ $.Values.image.validatorImage }}:{{ $.Values.image.version }}"
+        image: "{{ $.Values.image.validatorImage }}:{{ $.Values.image.versionTag }}"
         args:
         - lighthouse
         {{- if $.Values.ethereumTestnet }}

--- a/lighthouse/helm/values.yaml
+++ b/lighthouse/helm/values.yaml
@@ -50,7 +50,7 @@ beacon:
   # If the type is set to "hostPath", it represents the volume path on the host node.
   dataDirPath: /data/lighthouse/beacon
   # Ethereum 1 node endpoints.
-  eth1Endpoints: 
+  eth1Endpoints:
     - http://127.0.0.1:8545
     - http://127.0.0.1:8546
     

--- a/lighthouse/helm/values.yaml
+++ b/lighthouse/helm/values.yaml
@@ -39,7 +39,7 @@ image:
   validatorImage: index.docker.io/sigp/lighthouse
   # Lighthouse release version. 
   # Check https://github.com/sigp/lighthouse/releases for more info. 
-  version: v1.3.0
+  versionTag: v1.3.0
 
 # A required section that contains beacon chain information.
 beacon:

--- a/nimbus/helm/Chart.yaml
+++ b/nimbus/helm/Chart.yaml
@@ -4,4 +4,4 @@ description: A Helm chart for Ethereum 2 client - Nimbus
 
 type: application
 version: 0.1.1
-appVersion: "1.2.1"
+appVersion: "1.2.2"

--- a/nimbus/helm/Chart.yaml
+++ b/nimbus/helm/Chart.yaml
@@ -3,5 +3,5 @@ name: eth2-nimbus
 description: A Helm chart for Ethereum 2 client - Nimbus
 
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: "1.2.1"

--- a/nimbus/helm/templates/_unique_volumes_helper.tpl
+++ b/nimbus/helm/templates/_unique_volumes_helper.tpl
@@ -2,15 +2,11 @@
 {{- $volumeDict1 := dict .dataDirPath "beacon" }}
 {{- $volumeDict2 := dict .validatorsDirPath "validators" }} 
 {{- $volumeDict3 := dict .secretsDirPath "secrets" }}
-{{- $uniqueVolumePaths := keys $volumeDict1 $volumeDict2 $volumeDict3 | uniq }}
+{{- $uniqueVolumePaths := keys $volumeDict1 $volumeDict2 $volumeDict3 | uniq | sortAlpha }}
 {{- $finalDict := dict }}
-{{- if lt (len $uniqueVolumePaths) 3 }}
-  {{- range $path := $uniqueVolumePaths }}
-    {{- $tempValue := pluck $path $volumeDict1 $volumeDict2 $volumeDict3 | join "-" | printf "nimbus-%s-stroage" }}
-    {{- $finalDict := set $finalDict $path $tempValue }}
-  {{- end }}
-{{- else }}
-  {{- $finalDict := merge $finalDict $volumeDict1 $volumeDict2 $volumeDict3 }}
+{{- range $path := $uniqueVolumePaths }}
+  {{- $tempValue := pluck $path $volumeDict1 $volumeDict2 $volumeDict3 | join "-" | printf "nimbus-%s-storage" }}
+  {{- $finalDict := set $finalDict $path $tempValue }}
 {{- end }}
 {{- toYaml $finalDict -}}
 {{- end }}

--- a/nimbus/helm/templates/nimbus-deployment.yaml
+++ b/nimbus/helm/templates/nimbus-deployment.yaml
@@ -35,8 +35,7 @@ spec:
         - --data-dir={{ $client.dataDirPath }}
         - --validators-dir={{ $client.validatorsDirPath }}
         - --secrets-dir={{ $client.secretsDirPath }}
-        - --web3-url={{ $client.web3Provider }}
-        {{- range .fallbackWeb3Providers }}
+        {{- range .eth1Endpoints }}
         - --web3-url={{ . }}
         {{- end }}
         - --graffiti={{ $client.graffiti | quote }}

--- a/nimbus/helm/values.yaml
+++ b/nimbus/helm/values.yaml
@@ -51,7 +51,7 @@ nimbus:
       # This field specifies the name and label for Nimbus client deployment and container.
       name: nimbus-1
       # Ethereum 1 node endpoints.
-      eth1Endpoints: 
+      eth1Endpoints:
         - ws://127.0.0.1:8545
         - ws://127.0.0.1:8546
         - ws://127.0.0.1:8547
@@ -80,7 +80,7 @@ nimbus:
     # as long as the section has the same indentation as other Nimbus client sections and contains all the fields under the section name, e.g.
     # client2:
     #   name: nimbus-2
-    #   eth1Endpoints: 
+    #   eth1Endpoints:
     #     - ws://127.0.0.1:8545
     #   p2pUdpPort: 8000
     #   p2pTcpPort: 8000

--- a/nimbus/helm/values.yaml
+++ b/nimbus/helm/values.yaml
@@ -52,9 +52,9 @@ nimbus:
       name: nimbus-1
       # Ethereum 1 node endpoints.
       eth1Endpoints: 
-        - http://127.0.0.1:8545
-        - http://127.0.0.1:8546
-        - http://127.0.0.1:8547
+        - ws://127.0.0.1:8545
+        - ws://127.0.0.1:8546
+        - ws://127.0.0.1:8547
       # UDP Port opened for P2P connection with the beacon node.
       # See https://nimbus.guide/options.html for more info.
       p2pUdpPort: 9000
@@ -81,7 +81,7 @@ nimbus:
     # client2:
     #   name: nimbus-2
     #   eth1Endpoints: 
-    #     - http://127.0.0.1:8545
+    #     - ws://127.0.0.1:8545
     #   p2pUdpPort: 8000
     #   p2pTcpPort: 8000
     #   dataDirPath: /data/nimbus/beacon-2

--- a/nimbus/helm/values.yaml
+++ b/nimbus/helm/values.yaml
@@ -36,7 +36,7 @@ image:
   nimbusImage: index.docker.io/statusim/nimbus-eth2
   # Nimbus release version. 
   # Check https://github.com/status-im/nimbus-eth2/releases for release info. 
-  versionTag: amd64-v1.2.1
+  versionTag: amd64-v1.2.2
 
 # A required section that contains Nimbus client information.
 nimbus:
@@ -50,11 +50,9 @@ nimbus:
     client1:
       # This field specifies the name and label for Nimbus client deployment and container.
       name: nimbus-1
-      # Main Ethereum 1 node endpoint.
-      web3Provider: http://127.0.0.1:8545
-      # A list of Ethereum 1 node fallback endpoints. 
-      # When the main endpoint isn't available, Nimbus will use these fallback endpoints instead until the main endpoint becomes available again.
-      fallbackWeb3Providers:
+      # Ethereum 1 node endpoints.
+      eth1Endpoints: 
+        - http://127.0.0.1:8545
         - http://127.0.0.1:8546
         - http://127.0.0.1:8547
       # UDP Port opened for P2P connection with the beacon node.
@@ -82,8 +80,8 @@ nimbus:
     # as long as the section has the same indentation as other Nimbus client sections and contains all the fields under the section name, e.g.
     # client2:
     #   name: nimbus-2
-    #   web3Provider: http://127.0.0.1:8545
-    #   fallbackWeb3Providers:
+    #   eth1Endpoints: 
+    #     - http://127.0.0.1:8545
     #   p2pUdpPort: 8000
     #   p2pTcpPort: 8000
     #   dataDirPath: /data/nimbus/beacon-2

--- a/prysm/helm/Chart.yaml
+++ b/prysm/helm/Chart.yaml
@@ -4,4 +4,4 @@ description: A Helm chart for Ethereum 2 client - Prysm
 
 type: application
 version: 0.1.2
-appVersion: "1.3.8"
+appVersion: "1.3.9"

--- a/prysm/helm/Chart.yaml
+++ b/prysm/helm/Chart.yaml
@@ -3,5 +3,5 @@ name: eth2-prysm
 description: A Helm chart for Ethereum 2 client - Prysm
 
 type: application
-version: 0.1.1
+version: 0.1.2
 appVersion: "1.3.8"

--- a/prysm/helm/templates/_unique_volumes_helper.tpl
+++ b/prysm/helm/templates/_unique_volumes_helper.tpl
@@ -1,15 +1,11 @@
 {{- define "prysm.unique.volumes" }}
 {{- $volumeDict1 := dict .dataDirPath "validator" }} 
 {{- $volumeDict2 := dict .walletDirPath "wallet" }}
-{{- $uniqueVolumePaths := keys $volumeDict1 $volumeDict2 | uniq }}
+{{- $uniqueVolumePaths := keys $volumeDict1 $volumeDict2 | uniq | sortAlpha }}
 {{- $finalDict := dict }}
-{{- if lt (len $uniqueVolumePaths) 2 }}
-  {{- range $path := $uniqueVolumePaths }}
-    {{- $tempValue := pluck $path $volumeDict1 $volumeDict2 | join "-" | printf "prysm-%s-stroage" }}
-    {{- $finalDict := set $finalDict $path $tempValue }}
-  {{- end }}
-{{- else }}
-  {{- $finalDict := merge $finalDict $volumeDict1 $volumeDict2 }}
+{{- range $path := $uniqueVolumePaths }}
+  {{- $tempValue := pluck $path $volumeDict1 $volumeDict2 | join "-" | printf "prysm-%s-storage" }}
+  {{- $finalDict := set $finalDict $path $tempValue }}
 {{- end }}
 {{- toYaml $finalDict -}}
 {{- end }}

--- a/prysm/helm/templates/beacon-deployment.yaml
+++ b/prysm/helm/templates/beacon-deployment.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
       - name: {{ .name }}
-        image: "{{ $.Values.image.beaconImage }}:{{ $.Values.image.version }}"
+        image: "{{ $.Values.image.beaconImage }}:{{ $.Values.image.versionTag }}"
         args:
         {{- if $.Values.ethereumTestnet }}
         - --{{ $.Values.ethereumTestnet }}
@@ -28,8 +28,10 @@ spec:
         - --rpc-host=0.0.0.0
         - --p2p-tcp-port={{ .p2pTcpPort }}
         - --p2p-udp-port={{ .p2pUdpPort }}
-        - --http-web3provider={{ .web3Provider }}
-        {{- range .fallbackWeb3Providers }}
+        {{ if .eth1Endpoints }}
+        - --http-web3provider={{ first .eth1Endpoints }}
+        {{- end }}
+        {{- range rest .eth1Endpoints }}
         - --fallback-web3provider={{ . }}
         {{- end }}
         - --datadir=/data/prysm/beacon

--- a/prysm/helm/templates/beacon-deployment.yaml
+++ b/prysm/helm/templates/beacon-deployment.yaml
@@ -28,9 +28,7 @@ spec:
         - --rpc-host=0.0.0.0
         - --p2p-tcp-port={{ .p2pTcpPort }}
         - --p2p-udp-port={{ .p2pUdpPort }}
-        {{- if .eth1Endpoints }}
-        - --http-web3provider={{ first .eth1Endpoints }}
-        {{- end }}
+        - --http-web3provider={{ first (required "At least one eth1 endpoint is required." .eth1Endpoints) }}
         {{- range rest .eth1Endpoints }}
         - --fallback-web3provider={{ . }}
         {{- end }}

--- a/prysm/helm/templates/beacon-deployment.yaml
+++ b/prysm/helm/templates/beacon-deployment.yaml
@@ -28,7 +28,7 @@ spec:
         - --rpc-host=0.0.0.0
         - --p2p-tcp-port={{ .p2pTcpPort }}
         - --p2p-udp-port={{ .p2pUdpPort }}
-        {{ if .eth1Endpoints }}
+        {{- if .eth1Endpoints }}
         - --http-web3provider={{ first .eth1Endpoints }}
         {{- end }}
         {{- range rest .eth1Endpoints }}

--- a/prysm/helm/templates/validator-deployment.yaml
+++ b/prysm/helm/templates/validator-deployment.yaml
@@ -26,7 +26,7 @@ spec:
         command: ['sh', '-c', 'echo "Wait for {{ $.Values.validatorStartWaitTime }} second(s) for extra slashing protection!" && sleep {{ $.Values.validatorStartWaitTime }}']
       containers:
       - name: {{ $validatorClient.name }}
-        image: "{{ $.Values.image.validatorImage }}:{{ $.Values.image.version }}"
+        image: "{{ $.Values.image.validatorImage }}:{{ $.Values.image.versionTag }}"
         args:
         {{- if $.Values.ethereumTestnet }}
         - --{{ $.Values.ethereumTestnet }}

--- a/prysm/helm/values.yaml
+++ b/prysm/helm/values.yaml
@@ -42,7 +42,7 @@ image:
   validatorImage: gcr.io/prysmaticlabs/prysm/validator 
   # Prysm release version. 
   # Check https://github.com/prysmaticlabs/prysm/releases for more info. 
-  versionTag: v1.3.8-hotfix-6c0942
+  versionTag: v1.3.9
 
 # A required section that contains beacon chain information.
 beacon:

--- a/prysm/helm/values.yaml
+++ b/prysm/helm/values.yaml
@@ -42,7 +42,7 @@ image:
   validatorImage: gcr.io/prysmaticlabs/prysm/validator 
   # Prysm release version. 
   # Check https://github.com/prysmaticlabs/prysm/releases for more info. 
-  version: v1.3.8
+  versionTag: v1.3.8-hotfix+6c0942
 
 # A required section that contains beacon chain information.
 beacon:
@@ -58,12 +58,9 @@ beacon:
   # TCP Port opened for P2P connection with the beacon node.
   # See https://docs.prylabs.network/docs/prysm-usage/p2p-host-ip for more info.
   p2pTcpPort: 13000
-  # Main Ethereum 1 node endpoint.
-  web3Provider: http://127.0.0.1:8545
-  # Fallback Ethereum 1 node endpoints. 
-  # When the main endpoint isn't available, Prysm will use these fallback endpoints instead until the main endpoint becomes available again.
-  # See https://docs.prylabs.network/docs/prysm-usage/setup-eth1/#adding-fallback-eth1-nodes more info.
-  fallbackWeb3Providers:
+  # Ethereum 1 node endpoints.
+  eth1Endpoints: 
+    - http://127.0.0.1:8545
     - http://127.0.0.1:8546
     - http://127.0.0.1:8547
   # Specifying the genesis state file will allow users to skip generating the genesis state which takes a long time of reading eth1 deposit data.

--- a/prysm/helm/values.yaml
+++ b/prysm/helm/values.yaml
@@ -42,7 +42,7 @@ image:
   validatorImage: gcr.io/prysmaticlabs/prysm/validator 
   # Prysm release version. 
   # Check https://github.com/prysmaticlabs/prysm/releases for more info. 
-  versionTag: v1.3.8-hotfix+6c0942
+  versionTag: v1.3.8-hotfix-6c0942
 
 # A required section that contains beacon chain information.
 beacon:
@@ -59,7 +59,7 @@ beacon:
   # See https://docs.prylabs.network/docs/prysm-usage/p2p-host-ip for more info.
   p2pTcpPort: 13000
   # Ethereum 1 node endpoints.
-  eth1Endpoints: 
+  eth1Endpoints:
     - http://127.0.0.1:8545
     - http://127.0.0.1:8546
     - http://127.0.0.1:8547

--- a/teku/helm/Chart.yaml
+++ b/teku/helm/Chart.yaml
@@ -4,4 +4,4 @@ description: A Helm chart for Ethereum 2 client - Teku
 
 type: application
 version: 0.1.1
-appVersion: 21.4.1
+appVersion: 21.5.0

--- a/teku/helm/Chart.yaml
+++ b/teku/helm/Chart.yaml
@@ -3,5 +3,5 @@ name: eth2-teku
 description: A Helm chart for Ethereum 2 client - Teku
 
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: 21.4.1

--- a/teku/helm/templates/_unique_volumes_helper.tpl
+++ b/teku/helm/templates/_unique_volumes_helper.tpl
@@ -2,15 +2,11 @@
 {{- $volumeDict1 := dict .dataDirPath "validator" }}
 {{- $volumeDict2 := dict .validatorKeysDirPath "keys" }} 
 {{- $volumeDict3 := dict .validatorKeyPasswordsDirPath "passwords" }}
-{{- $uniqueVolumePaths := keys $volumeDict1 $volumeDict2 $volumeDict3 | uniq }}
+{{- $uniqueVolumePaths := keys $volumeDict1 $volumeDict2 $volumeDict3 | uniq | sortAlpha }}
 {{- $finalDict := dict }}
-{{- if lt (len $uniqueVolumePaths) 3 }}
-  {{- range $path := $uniqueVolumePaths }}
-    {{- $tempValue := pluck $path $volumeDict1 $volumeDict2 $volumeDict3 | join "-" | printf "teku-%s-stroage" }}
-    {{- $finalDict := set $finalDict $path $tempValue }}
-  {{- end }}
-{{- else }}
-  {{- $finalDict := merge $finalDict $volumeDict1 $volumeDict2 $volumeDict3 }}
+{{- range $path := $uniqueVolumePaths }}
+  {{- $tempValue := pluck $path $volumeDict1 $volumeDict2 $volumeDict3 | join "-" | printf "teku-%s-storage" }}
+  {{- $finalDict := set $finalDict $path $tempValue }}
 {{- end }}
 {{- toYaml $finalDict -}}
 {{- end }}

--- a/teku/helm/templates/beacon-deployment.yaml
+++ b/teku/helm/templates/beacon-deployment.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
       - name: {{ .name }}
-        image: "{{ $.Values.image.beaconImage }}:{{ $.Values.image.version }}"
+        image: "{{ $.Values.image.beaconImage }}:{{ $.Values.image.versionTag }}"
         args:
         {{- if $.Values.ethereumTestnet }}
         - --network={{ $.Values.ethereumTestnet }}
@@ -28,7 +28,7 @@ spec:
         - --p2p-port={{ .p2pPort }}
         - --rest-api-enabled
         - --rest-api-host-allowlist={{ $.Values.beacon.name }}-service.{{ $.Values.namespace }}.svc.cluster.local
-        - --eth1-endpoint={{ .eth1Endpoint }}
+        - --eth1-endpoints={{ .eth1Endpoints | join "," }}
         - --data-beacon-path=/data/teku/beacon
         - --log-destination=CONSOLE
         ports:

--- a/teku/helm/templates/validator-deployment.yaml
+++ b/teku/helm/templates/validator-deployment.yaml
@@ -24,7 +24,7 @@ spec:
         command: ['sh', '-c', 'echo "Wait for {{ $.Values.validatorStartWaitTime }} second(s) for extra slashing protection!" && sleep {{ $.Values.validatorStartWaitTime }}']
       containers:
       - name: {{ $validatorClient.name }}
-        image: "{{ $.Values.image.validatorImage }}:{{ $.Values.image.version }}"
+        image: "{{ $.Values.image.validatorImage }}:{{ $.Values.image.versionTag }}"
         args:
         - vc 
         {{- if $.Values.ethereumTestnet }}

--- a/teku/helm/values.yaml
+++ b/teku/helm/values.yaml
@@ -39,7 +39,7 @@ image:
   validatorImage: index.docker.io/consensys/teku
   # Teku release version. 
   # Check https://github.com/consensys/teku/releases for more info. 
-  version: 21.4.1
+  versionTag: 21.4.1
 
 # A required section that contains beacon chain information.
 beacon:
@@ -49,8 +49,11 @@ beacon:
   # If persistentVolumeType is set to "nfs", this variable represents the data volume path on NFS.
   # If the type is set to "hostPath", it represents the volume path on the host node.
   dataDirPath: /data/teku/beacon
-  # Ethereum 1 node endpoint.
-  eth1Endpoint: http://127.0.0.1:8545
+  # Ethereum 1 node endpoints.
+  eth1Endpoints: 
+    - http://127.0.0.1:8545
+    - http://127.0.0.1:8546
+    - http://127.0.0.1:8547
   # TCP and UDP port opened for P2P connection with the beacon node.
   # See https://docs.teku.consensys.net/en/latest/Reference/CLI/CLI-Syntax/#p2p-port for more info.
   p2pPort: 9000

--- a/teku/helm/values.yaml
+++ b/teku/helm/values.yaml
@@ -39,7 +39,7 @@ image:
   validatorImage: index.docker.io/consensys/teku
   # Teku release version. 
   # Check https://github.com/consensys/teku/releases for more info. 
-  versionTag: 21.4.1
+  versionTag: 21.5.0
 
 # A required section that contains beacon chain information.
 beacon:

--- a/teku/helm/values.yaml
+++ b/teku/helm/values.yaml
@@ -50,7 +50,7 @@ beacon:
   # If the type is set to "hostPath", it represents the volume path on the host node.
   dataDirPath: /data/teku/beacon
   # Ethereum 1 node endpoints.
-  eth1Endpoints: 
+  eth1Endpoints:
     - http://127.0.0.1:8545
     - http://127.0.0.1:8546
     - http://127.0.0.1:8547


### PR DESCRIPTION
- Keep the storage in the volume naming. 
- Bump Chart patch release version for Nimbus, Prysm, Lighthouse and Teku.
- Bump Prysm, Teku and Nimbus client version in values.yaml and Chart.yaml.
- Update README to reflect the changes.