### PR TITLE
Bump client version and add checkpoint sync for teku.

### DIFF
--- a/teku/helm/Chart.yaml
+++ b/teku/helm/Chart.yaml
@@ -3,5 +3,5 @@ name: eth2-teku
 description: A Helm chart for Ethereum 2 client - Teku
 
 type: application
-version: 0.1.2
-appVersion: 21.6.0
+version: 0.1.3
+appVersion: 22.4.0

--- a/teku/helm/templates/_unique_volumes_helper_beacon.tpl
+++ b/teku/helm/templates/_unique_volumes_helper_beacon.tpl
@@ -1,0 +1,11 @@
+{{- define "teku.unique.volumes.beacon" }}
+{{- $volumeDict1 := dict .dataDirPath "beacon" }}
+{{- $volumeDict2 := dict .localDirPath "local" }}
+{{- $uniqueVolumePaths := keys $volumeDict1 $volumeDict2 | uniq | sortAlpha }}
+{{- $finalDict := dict }}
+{{- range $path := $uniqueVolumePaths }}
+  {{- $tempValue := pluck $path $volumeDict1 $volumeDict2 | join "-" | printf "teku-%s-storage" }}
+  {{- $finalDict := set $finalDict $path $tempValue }}
+{{- end }}
+{{- toYaml $finalDict -}}
+{{- end }}

--- a/teku/helm/templates/_unique_volumes_helper_validator.tpl
+++ b/teku/helm/templates/_unique_volumes_helper_validator.tpl
@@ -1,11 +1,12 @@
-{{- define "teku.unique.volumes" }}
+{{- define "teku.unique.volumes.validator" }}
 {{- $volumeDict1 := dict .dataDirPath "validator" }}
 {{- $volumeDict2 := dict .validatorKeysDirPath "keys" }} 
 {{- $volumeDict3 := dict .validatorKeyPasswordsDirPath "passwords" }}
-{{- $uniqueVolumePaths := keys $volumeDict1 $volumeDict2 $volumeDict3 | uniq | sortAlpha }}
+{{- $volumeDict4 := dict .localDirPath "local" }}
+{{- $uniqueVolumePaths := keys $volumeDict1 $volumeDict2 $volumeDict3 $volumeDict4 | uniq | sortAlpha }}
 {{- $finalDict := dict }}
 {{- range $path := $uniqueVolumePaths }}
-  {{- $tempValue := pluck $path $volumeDict1 $volumeDict2 $volumeDict3 | join "-" | printf "teku-%s-storage" }}
+  {{- $tempValue := pluck $path $volumeDict1 $volumeDict2 $volumeDict3 $volumeDict4 | join "-" | printf "teku-%s-storage" }}
   {{- $finalDict := set $finalDict $path $tempValue }}
 {{- end }}
 {{- toYaml $finalDict -}}

--- a/teku/helm/templates/_volume_mounts.tpl
+++ b/teku/helm/templates/_volume_mounts.tpl
@@ -1,8 +1,0 @@
-{{- define "teku.volumeMounts" }}
-{{- $uniqueVolumes := fromYaml (include "teku.unique.volumes" . ) }}
-{{- range $volumePath, $volumeName := $uniqueVolumes }}
-- name: {{ $volumeName }}
-  mountPath: {{ $volumePath }}
-  readOnly: {{ and (ne $volumePath $.dataDirPath) (ne $volumePath $.validatorKeysDirPath) }}
-{{- end -}}
-{{- end -}}

--- a/teku/helm/templates/_volume_mounts_beacon.tpl
+++ b/teku/helm/templates/_volume_mounts_beacon.tpl
@@ -1,0 +1,12 @@
+{{- define "teku.volumeMounts.beacon" }}
+{{- $uniqueVolumes := fromYaml (include "teku.unique.volumes.beacon" . ) }}
+{{- range $volumePath, $volumeName := $uniqueVolumes }}
+- name: {{ $volumeName }}
+{{- if eq $volumeName "teku-local-storage"}}
+  mountPath: /.local/share/teku
+{{- else}}
+  mountPath: {{ $volumePath }}
+{{- end}}
+  readOnly: false
+{{- end -}}
+{{- end -}}

--- a/teku/helm/templates/_volume_mounts_validator.tpl
+++ b/teku/helm/templates/_volume_mounts_validator.tpl
@@ -1,0 +1,12 @@
+{{- define "teku.volumeMounts.validator" }}
+{{- $uniqueVolumes := fromYaml (include "teku.unique.volumes.validator" . ) }}
+{{- range $volumePath, $volumeName := $uniqueVolumes }}
+- name: {{ $volumeName }}
+{{- if eq $volumeName "teku-local-storage"}}
+  mountPath: /.local/share/teku
+{{- else}}
+  mountPath: {{ $volumePath }}
+{{- end}}
+  readOnly: {{ eq $volumePath $.validatorKeyPasswordsDirPath }}
+{{- end -}}
+{{- end -}}

--- a/teku/helm/templates/_volumes_beacon.tpl
+++ b/teku/helm/templates/_volumes_beacon.tpl
@@ -1,0 +1,15 @@
+{{- define "teku.volumes.beacon" }}
+{{- $uniqueVolumes := fromYaml (include "teku.unique.volumes.beacon" . ) }}
+{{- range $volumePath, $volumeName := $uniqueVolumes }}
+- name: {{ $volumeName }}
+{{- if eq $.persistentVolumeType "nfs" }}
+  nfs:
+    path: {{ $volumePath }}
+    server: {{ $.nfs.serverIp }}
+    readOnly: false
+{{- else }}
+  hostPath:
+    path: {{ $volumePath }}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/teku/helm/templates/_volumes_validator.tpl
+++ b/teku/helm/templates/_volumes_validator.tpl
@@ -1,12 +1,12 @@
-{{- define "teku.volumes" }}
-{{- $uniqueVolumes := fromYaml (include "teku.unique.volumes" . ) }}
+{{- define "teku.volumes.validator" }}
+{{- $uniqueVolumes := fromYaml (include "teku.unique.volumes.validator" . ) }}
 {{- range $volumePath, $volumeName := $uniqueVolumes }}
 - name: {{ $volumeName }}
 {{- if eq $.persistentVolumeType "nfs" }}
   nfs:
     path: {{ $volumePath }}
     server: {{ $.nfs.serverIp }}
-    readOnly: {{ and (ne $volumePath $.dataDirPath) (ne $volumePath $.validatorKeysDirPath) }}
+    readOnly: {{ eq $volumePath $.validatorKeyPasswordsDirPath }}
 {{- else }}
   hostPath:
     path: {{ $volumePath }}

--- a/teku/helm/templates/beacon-deployment.yaml
+++ b/teku/helm/templates/beacon-deployment.yaml
@@ -33,6 +33,9 @@ spec:
         - --log-destination=CONSOLE
         - --metrics-enabled=true
         - --metrics-interface=0.0.0.0
+        {{- if .checkpointSyncURL }}
+        - --initial-state={{ .checkpointSyncURL }}
+        {{- end }}
         ports:
         - containerPort: {{ .p2pPort }}
           hostPort: {{ .p2pPort }}
@@ -47,8 +50,7 @@ spec:
           protocol: TCP
           name: metrics
         volumeMounts:
-        - name: beacon-storage
-          mountPath: /data/teku/beacon
+        {{- include "teku.volumeMounts.beacon" (merge . (pick $.Values "localDirPath" ))  | indent 8 }}
         livenessProbe:
           httpGet:
             path: /teku/v1/admin/liveness
@@ -70,16 +72,7 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
       volumes:
-      - name: beacon-storage
-        {{- if eq $.Values.persistentVolumeType "nfs" }}
-        nfs:
-          path: {{ .dataDirPath }}
-          server: {{ $.Values.nfs.serverIp }}
-          readOnly: false
-        {{- else }}
-        hostPath:
-          path: {{ .dataDirPath }}
-        {{- end }}
+      {{- include "teku.volumes.beacon" (merge . (pick $.Values "persistentVolumeType" "nfs" "localDirPath" )) | indent 6 }}
       securityContext:
         {{- toYaml $.Values.securityContext | nindent 8 }}
       serviceAccountName: beacon

--- a/teku/helm/templates/validator-deployment.yaml
+++ b/teku/helm/templates/validator-deployment.yaml
@@ -42,9 +42,9 @@ spec:
           protocol: TCP
           name: metrics
         volumeMounts:
-        {{- include "teku.volumeMounts" $validatorClient | indent 8 }}
+        {{- include "teku.volumeMounts.validator" (merge $validatorClient (pick $.Values "localDirPath" ))  | indent 8 }}
       volumes:
-      {{- include "teku.volumes" (merge $validatorClient (pick $.Values "persistentVolumeType" "nfs")) | indent 6 }}
+      {{- include "teku.volumes.validator" (merge $validatorClient (pick $.Values "persistentVolumeType" "nfs" "localDirPath" )) | indent 6 }}
       securityContext:
         {{- toYaml $.Values.securityContext | nindent 8 }}
       serviceAccountName: validator-client

--- a/teku/helm/values.yaml
+++ b/teku/helm/values.yaml
@@ -16,6 +16,10 @@ nfs:
   # IP address of the NFS server.
   serverIp: 172.20.10.10
 
+# Local folder to store logs and other data.
+# See https://docs.teku.consensys.net/en/latest/HowTo/Monitor/Logging/ for more info.
+localDirPath: /data/teku/local
+
 securityContext:
   # The user ID will be used to run all processes in the container. The user should have the access to the mounted volume.
   # All directories and files created with the processes are owned by this user.
@@ -39,7 +43,7 @@ image:
   validatorImage: index.docker.io/consensys/teku
   # Teku release version. 
   # Check https://github.com/consensys/teku/releases for more info. 
-  versionTag: 21.6.0
+  versionTag: 22.4.0
 
 # A required section that contains beacon chain information.
 beacon:
@@ -57,6 +61,10 @@ beacon:
   # TCP and UDP port opened for P2P connection with the beacon node.
   # See https://docs.teku.consensys.net/en/latest/Reference/CLI/CLI-Syntax/#p2p-port for more info.
   p2pPort: 9000
+  # An optional flag to enable syncing from a recent finalized checkpoint instead of syncing from genesis.
+  # To enable this functionality, set this flag to another synced beacon node and delete the existing beacon database.
+  # Check https://docs.teku.consensys.net/en/latest/HowTo/Get-Started/Checkpoint-Start/ for more info.
+  # checkpointSyncURL: https://<PROJECT-ID>:<PROJECT-SECRET>@eth2-beacon-mainnet.infura.io/eth/v2/debug/beacon/states/finalized
 
 # This field determines how long it will wait before the validator client starts or restarts.
 # It's a way to protect the validator client from double attesting or block proposing when the DB is out-of-date.


### PR DESCRIPTION
- Bump teku client version to https://github.com/ConsenSys/teku/releases/tag/22.4.0.
- Add checkpoint sync functionality by adding initial-state flag (See https://docs.teku.consensys.net/en/latest/HowTo/Get-Started/Checkpoint-Start/).
- Add volume mount for /.local/share/teku (See https://docs.teku.consensys.net/en/latest/HowTo/Monitor/Logging/).

This closes #45 and #46.